### PR TITLE
Fix crash in release build on certain runtime combinations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ option(BUILD_VAMP_PLUGIN "Build Vamp plugin" ON)
 set(CMAKE_CXX_STANDARD 17)
 
 if (MSVC)
+    # Fix crash on older runtimes: https://github.com/microsoft/STL/wiki/Changelog#vs-2022-1710
+    add_definitions(-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+    
     # Suppress specific MSVC warnings
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
     add_compile_options(

--- a/vamp-plugin/LteVampBase.cpp
+++ b/vamp-plugin/LteVampBase.cpp
@@ -4,9 +4,6 @@
 #include <thread>
 #include <vamp-sdk/PluginAdapter.h>
 
-#ifdef NDEBUG
-#error For some obscure reason, the DLL doesn't get loaded by sonic visualiser when built in Release mode. If you can fix this then please remove this error.
-#endif
 
 namespace
 {
@@ -29,10 +26,6 @@ LteVampBase::LteVampBase(float inputSampleRate)
     , mSampleCount(LTE::FileUtils::ReadFromAppDataFile())
     , mAudioReader(inputSampleRate)
 {
-   // This was an unsuccessfuly attempt to make the plugin work in Sonic
-   // Visualiser also in Release mode. Doesn't work, but let's leave it here to
-   // show that the experiment has already been done.
-   (void*)&vampGetPluginDescriptor;
 }
 
 std::string LteVampBase::getIdentifier() const


### PR DESCRIPTION
Fix: #3 

https://github.com/microsoft/STL/wiki/Changelog#vs-2022-1710


> Fixed bugs:
> Fixed mutex's constructor to be constexpr. [#3824](https://github.com/microsoft/STL/pull/3824) [#4000](https://github.com/microsoft/STL/pull/4000) [#4339](https://github.com/microsoft/STL/pull/4339)
> Note: Programs that aren't following the documented [restrictions on binary compatibility](https://learn.microsoft.com/en-us/cpp/porting/binary-compat-2015-2017?view=msvc-170) may encounter null dereferences in mutex machinery. You must follow this rule:
> When you mix binaries built by different supported versions of the toolset, the Redistributable version must be at least as new as the latest toolset used by any app component.
> 
> You can define _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR as an escape hatch.
