### PR TITLE
Fix detection for all zeros odf

### DIFF
--- a/source/GetMeterUsingTatumQuantizationFit.cpp
+++ b/source/GetMeterUsingTatumQuantizationFit.cpp
@@ -123,9 +123,10 @@ int GetOnsetLag(const std::vector<float>& odf, int numTatums)
    // train of frequency `numTatums / odf.size()`. We take the position of the
    // first peak to be the lag.
    const auto pulseTrainPeriod = 1. * odf.size() / numTatums;
+   const auto maxLag = static_cast<int>(std::round(pulseTrainPeriod));
    auto max = std::numeric_limits<float>::lowest();
-   auto lag = 0;
-   while (true)
+   auto bestLag = 0;
+   for(int lag = 0; lag < maxLag; ++lag)
    {
       auto val = 0.f;
       for (auto i = 0; i < numTatums; ++i)
@@ -134,11 +135,12 @@ int GetOnsetLag(const std::vector<float>& odf, int numTatums)
          val += (j < odf.size() ? odf[j] : 0.f);
       }
       if (val < max)
-         break;
-      max = val;
-      ++lag;
+      {
+         max = val;
+         bestLag = lag;
+      }
    }
-   return lag - 1;
+   return bestLag;
 }
 
 // This is the fundament of the algorithm. It gives a weighted average of the

--- a/tests/test-utils/LteFakes.h
+++ b/tests/test-utils/LteFakes.h
@@ -46,4 +46,23 @@ class SquareWaveLteAudioReader : public LteAudioReader
    }
 };
 
+class SilenceLteAudioReader : public LteAudioReader
+{
+   const int period = 3;
+   const int sampleRate = 44100;
+
+   double GetSampleRate() const override
+   {
+      return sampleRate;
+   }
+   long long GetNumSamples() const override
+   {
+      return period * sampleRate;
+   }
+   void ReadFloats(float* buffer, long long, size_t numFrames) const override
+   {
+      std::fill(buffer, buffer + numFrames, 0.f);
+   }
+};
+
 } // namespace LTE

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(unit-tests
+        GetBpmTest.cpp
         MathApproxTest.cpp
         StftFrameProviderTests.cpp
 )

--- a/tests/unit-tests/GetBpmTest.cpp
+++ b/tests/unit-tests/GetBpmTest.cpp
@@ -1,0 +1,14 @@
+#include "LteFakes.h"
+#include "LoopTempoEstimator/LoopTempoEstimator.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("GetBpm returns nullopt for silence")
+{
+   using namespace LTE;
+   const SilenceLteAudioReader audio;
+   std::function<void(double)> progressCb;
+   const auto result =
+      GetBpm(audio, FalsePositiveTolerance::Lenient, progressCb);
+   REQUIRE(!result.has_value());
+}


### PR DESCRIPTION
If odf is all zeros `GetOnsetLag` function does not return.
If the idea is to cross correlate with a train of impulses we can just do the check on a single period.