### PR TITLE
Fix detection for all zeros odf

### DIFF
--- a/source/GetMeterUsingTatumQuantizationFit.cpp
+++ b/source/GetMeterUsingTatumQuantizationFit.cpp
@@ -123,10 +123,10 @@ int GetOnsetLag(const std::vector<float>& odf, int numTatums)
    // train of frequency `numTatums / odf.size()`. We take the position of the
    // first peak to be the lag.
    const auto pulseTrainPeriod = 1. * odf.size() / numTatums;
-   const auto maxLag = static_cast<int>(std::round(pulseTrainPeriod));
    auto max = std::numeric_limits<float>::lowest();
-   auto bestLag = 0;
-   for(int lag = 0; lag < maxLag; ++lag)
+   const auto maxLag = static_cast<int>(std::round(pulseTrainPeriod));
+
+   for (int lag = 0; lag < maxLag; ++lag)
    {
       auto val = 0.f;
       for (auto i = 0; i < numTatums; ++i)
@@ -134,13 +134,15 @@ int GetOnsetLag(const std::vector<float>& odf, int numTatums)
          const int j = std::round(i * pulseTrainPeriod) + lag;
          val += (j < odf.size() ? odf[j] : 0.f);
       }
-      if (val < max)
-      {
-         max = val;
-         bestLag = lag;
+
+      if(val < max) {
+         return lag - 1;
       }
+
+      max = val;
    }
-   return bestLag;
+
+   return 0;
 }
 
 // This is the fundament of the algorithm. It gives a weighted average of the


### PR DESCRIPTION
If the odf vector is all zeros, the `GetOnsetLag` function blocks.
Once the test is basically a cross correlation with a pulse train of period `pulseTrainPeriod` we can do the test on the first period only.